### PR TITLE
Changes to get tests passing on python 3.7

### DIFF
--- a/ddexreader/__init__.py
+++ b/ddexreader/__init__.py
@@ -1,3 +1,3 @@
 __version__ = '0.1.1'
 
-from ddexreader import *
+from .ddexreader import *

--- a/ddexreader/ddexreader.py
+++ b/ddexreader/ddexreader.py
@@ -26,21 +26,21 @@ def open_ddex(path):
     with open(path, 'rb') as f:
         xml_data = f.read()
 
-    if 'MessageSchemaVersionId="2010/ern-main/312"' in xml_data:
+    if b'MessageSchemaVersionId="2010/ern-main/312"' in xml_data:
         return ern312.CreateFromDocument(xml_data)
-    elif 'MessageSchemaVersionId="ern/32"' in xml_data:
+    elif b'MessageSchemaVersionId="ern/32"' in xml_data:
         return ern32.CreateFromDocument(xml_data)
-    elif 'MessageSchemaVersionId="2011/ern-main/33"' in xml_data:
+    elif b'MessageSchemaVersionId="2011/ern-main/33"' in xml_data:
         return ern33.CreateFromDocument(xml_data)
-    elif 'MessageSchemaVersionId="ern/34"' in xml_data:
+    elif b'MessageSchemaVersionId="ern/34"' in xml_data:
         return ern34.CreateFromDocument(xml_data)
-    elif 'MessageSchemaVersionId="ern/341"' in xml_data:
+    elif b'MessageSchemaVersionId="ern/341"' in xml_data:
         return ern341.CreateFromDocument(xml_data)
-    elif 'MessageSchemaVersionId="ern/35"' in xml_data:
+    elif b'MessageSchemaVersionId="ern/35"' in xml_data:
         return ern35.CreateFromDocument(xml_data)
-    elif 'MessageSchemaVersionId="ern/351"' in xml_data:
+    elif b'MessageSchemaVersionId="ern/351"' in xml_data:
         return ern351.CreateFromDocument(xml_data)
-    elif 'MessageSchemaVersionId="ern/36"' in xml_data:
+    elif b'MessageSchemaVersionId="ern/36"' in xml_data:
         return ern36.CreateFromDocument(xml_data)
     else:
         raise ValueError('No ERN version compatible with this DDEX file.')
@@ -62,7 +62,7 @@ def ddex_to_dict(ddex):
 
     # Check if we have a leaf type (which means its repr will be a string containing a unicode string)
     if 'object' not in repr(ddex):
-        return unicode(ddex)
+        return str(ddex)
     d = {}
 
     for attr in attributes:

--- a/ddexreader/ddexreader.py
+++ b/ddexreader/ddexreader.py
@@ -1,12 +1,12 @@
 import pyxb
-import ern312
-import ern32
-import ern33
-import ern34
-import ern341
-import ern35
-import ern351
-import ern36
+from . import ern312
+from . import ern32
+from . import ern33
+from . import ern34
+from . import ern341
+from . import ern35
+from . import ern351
+from . import ern36
 
 
 def open_ddex(path):

--- a/ddexreader/ern312/__init__.py
+++ b/ddexreader/ern312/__init__.py
@@ -1,1 +1,1 @@
-from binding import *
+from .binding import *

--- a/ddexreader/ern312/_ddexC.py
+++ b/ddexreader/ern312/_ddexC.py
@@ -24,10 +24,10 @@ if pyxb.__version__ != _PyXBVersion:
     raise pyxb.PyXBVersionError(_PyXBVersion)
 
 # Import bindings for namespaces imported into schema
-import _iso3166a2 as _ImportedBinding__iso3166a2
-import _ddex as _ImportedBinding__ddex
-import _iso639a2 as _ImportedBinding__iso639a2
-import _iso4217a as _ImportedBinding__iso4217a
+from . import _iso3166a2 as _ImportedBinding__iso3166a2
+from . import _ddex as _ImportedBinding__ddex
+from . import _iso639a2 as _ImportedBinding__iso639a2
+from . import _iso4217a as _ImportedBinding__iso4217a
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding

--- a/ddexreader/ern312/binding.py
+++ b/ddexreader/ern312/binding.py
@@ -24,9 +24,9 @@ if pyxb.__version__ != _PyXBVersion:
     raise pyxb.PyXBVersionError(_PyXBVersion)
 
 # Import bindings for namespaces imported into schema
-import _ddexC as _ImportedBinding__ddexC
-import _ddex as _ImportedBinding__ddex
-import _iso639a2 as _ImportedBinding__iso639a2
+from . import _ddexC as _ImportedBinding__ddexC
+from . import _ddex as _ImportedBinding__ddex
+from . import _iso639a2 as _ImportedBinding__iso639a2
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding

--- a/ddexreader/ern32/__init__.py
+++ b/ddexreader/ern32/__init__.py
@@ -1,1 +1,1 @@
-from binding import *
+from .binding import *

--- a/ddexreader/ern32/_ddexC.py
+++ b/ddexreader/ern32/_ddexC.py
@@ -24,11 +24,11 @@ if pyxb.__version__ != _PyXBVersion:
     raise pyxb.PyXBVersionError(_PyXBVersion)
 
 # Import bindings for namespaces imported into schema
-import _iso4217a as _ImportedBinding__iso4217a
+from . import _iso4217a as _ImportedBinding__iso4217a
 import pyxb.binding.datatypes
-import _iso639a2 as _ImportedBinding__iso639a2
-import _ddex as _ImportedBinding__ddex
-import _iso3166a2 as _ImportedBinding__iso3166a2
+from . import _iso639a2 as _ImportedBinding__iso639a2
+from . import _ddex as _ImportedBinding__ddex
+from . import _iso3166a2 as _ImportedBinding__iso3166a2
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ddex.net/xml/20100712/ddexC', create_if_missing=True)

--- a/ddexreader/ern32/binding.py
+++ b/ddexreader/ern32/binding.py
@@ -25,9 +25,9 @@ if pyxb.__version__ != _PyXBVersion:
 
 # Import bindings for namespaces imported into schema
 import pyxb.binding.datatypes
-import _iso639a2 as _ImportedBinding__iso639a2
-import _ddex as _ImportedBinding__ddex
-import _ddexC as _ImportedBinding__ddexC
+from . import _iso639a2 as _ImportedBinding__iso639a2
+from . import _ddex as _ImportedBinding__ddex
+from . import _ddexC as _ImportedBinding__ddexC
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ddex.net/xml/2010/ern-main/32', create_if_missing=True)

--- a/ddexreader/ern33/__init__.py
+++ b/ddexreader/ern33/__init__.py
@@ -1,1 +1,1 @@
-from binding import *
+from .binding import *

--- a/ddexreader/ern33/_ddexC.py
+++ b/ddexreader/ern33/_ddexC.py
@@ -25,10 +25,10 @@ if pyxb.__version__ != _PyXBVersion:
 
 # Import bindings for namespaces imported into schema
 import pyxb.binding.datatypes
-import _iso639a2 as _ImportedBinding__iso639a2
-import _iso4217a as _ImportedBinding__iso4217a
-import _iso3166a2 as _ImportedBinding__iso3166a2
-import _ddex as _ImportedBinding__ddex
+from . import _iso639a2 as _ImportedBinding__iso639a2
+from . import _iso4217a as _ImportedBinding__iso4217a
+from . import _iso3166a2 as _ImportedBinding__iso3166a2
+from . import _ddex as _ImportedBinding__ddex
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ddex.net/xml/20110630/ddexC', create_if_missing=True)

--- a/ddexreader/ern33/binding.py
+++ b/ddexreader/ern33/binding.py
@@ -25,9 +25,9 @@ if pyxb.__version__ != _PyXBVersion:
 
 # Import bindings for namespaces imported into schema
 import pyxb.binding.datatypes
-import _iso639a2 as _ImportedBinding__iso639a2
-import _ddexC as _ImportedBinding__ddexC
-import _ddex as _ImportedBinding__ddex
+from . import _iso639a2 as _ImportedBinding__iso639a2
+from . import _ddexC as _ImportedBinding__ddexC
+from . import _ddex as _ImportedBinding__ddex
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ddex.net/xml/2011/ern-main/33', create_if_missing=True)

--- a/ddexreader/ern34/__init__.py
+++ b/ddexreader/ern34/__init__.py
@@ -1,1 +1,1 @@
-from binding import *
+from .binding import *

--- a/ddexreader/ern34/_ddexC.py
+++ b/ddexreader/ern34/_ddexC.py
@@ -25,10 +25,10 @@ if pyxb.__version__ != _PyXBVersion:
 
 # Import bindings for namespaces imported into schema
 import pyxb.binding.datatypes
-import _iso3166a2 as _ImportedBinding__iso3166a2
-import _iso639a2 as _ImportedBinding__iso639a2
-import _ddex as _ImportedBinding__ddex
-import _iso4217a as _ImportedBinding__iso4217a
+from . import _iso3166a2 as _ImportedBinding__iso3166a2
+from . import _iso639a2 as _ImportedBinding__iso639a2
+from . import _ddex as _ImportedBinding__ddex
+from . import _iso4217a as _ImportedBinding__iso4217a
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ddex.net/xml/20120214/ddexC', create_if_missing=True)

--- a/ddexreader/ern34/binding.py
+++ b/ddexreader/ern34/binding.py
@@ -25,9 +25,9 @@ if pyxb.__version__ != _PyXBVersion:
 
 # Import bindings for namespaces imported into schema
 import pyxb.binding.datatypes
-import _iso639a2 as _ImportedBinding__iso639a2
-import _ddex as _ImportedBinding__ddex
-import _ddexC as _ImportedBinding__ddexC
+from . import _iso639a2 as _ImportedBinding__iso639a2
+from . import _ddex as _ImportedBinding__ddex
+from . import _ddexC as _ImportedBinding__ddexC
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ddex.net/xml/ern/34', create_if_missing=True)

--- a/ddexreader/ern341/__init__.py
+++ b/ddexreader/ern341/__init__.py
@@ -1,1 +1,1 @@
-from binding import *
+from .binding import *

--- a/ddexreader/ern341/_ddexC.py
+++ b/ddexreader/ern341/_ddexC.py
@@ -25,10 +25,10 @@ if pyxb.__version__ != _PyXBVersion:
 
 # Import bindings for namespaces imported into schema
 import pyxb.binding.datatypes
-import _iso3166a2 as _ImportedBinding__iso3166a2
-import _iso639a2 as _ImportedBinding__iso639a2
-import _ddex as _ImportedBinding__ddex
-import _iso4217a as _ImportedBinding__iso4217a
+from . import _iso3166a2 as _ImportedBinding__iso3166a2
+from . import _iso639a2 as _ImportedBinding__iso639a2
+from . import _ddex as _ImportedBinding__ddex
+from . import _iso4217a as _ImportedBinding__iso4217a
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ddex.net/xml/20120404/ddexC', create_if_missing=True)

--- a/ddexreader/ern341/binding.py
+++ b/ddexreader/ern341/binding.py
@@ -25,9 +25,9 @@ if pyxb.__version__ != _PyXBVersion:
 
 # Import bindings for namespaces imported into schema
 import pyxb.binding.datatypes
-import _iso639a2 as _ImportedBinding__iso639a2
-import _ddex as _ImportedBinding__ddex
-import _ddexC as _ImportedBinding__ddexC
+from . import _iso639a2 as _ImportedBinding__iso639a2
+from . import _ddex as _ImportedBinding__ddex
+from . import _ddexC as _ImportedBinding__ddexC
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ddex.net/xml/ern/341', create_if_missing=True)

--- a/ddexreader/ern35/__init__.py
+++ b/ddexreader/ern35/__init__.py
@@ -1,1 +1,1 @@
-from binding import *
+from .binding import *

--- a/ddexreader/ern35/_ddexC.py
+++ b/ddexreader/ern35/_ddexC.py
@@ -24,11 +24,11 @@ if pyxb.__version__ != _PyXBVersion:
     raise pyxb.PyXBVersionError(_PyXBVersion)
 
 # Import bindings for namespaces imported into schema
-import _iso639a2 as _ImportedBinding__iso639a2
+from . import _iso639a2 as _ImportedBinding__iso639a2
 import pyxb.binding.datatypes
-import _iso3166a2 as _ImportedBinding__iso3166a2
-import _ddex as _ImportedBinding__ddex
-import _iso4217a as _ImportedBinding__iso4217a
+from . import _iso3166a2 as _ImportedBinding__iso3166a2
+from . import _ddex as _ImportedBinding__ddex
+from . import _iso4217a as _ImportedBinding__iso4217a
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ddex.net/xml/20120719/ddexC', create_if_missing=True)

--- a/ddexreader/ern35/binding.py
+++ b/ddexreader/ern35/binding.py
@@ -25,9 +25,9 @@ if pyxb.__version__ != _PyXBVersion:
 
 # Import bindings for namespaces imported into schema
 import pyxb.binding.datatypes
-import _iso639a2 as _ImportedBinding__iso639a2
-import _ddexC as _ImportedBinding__ddexC
-import _ddex as _ImportedBinding__ddex
+from . import _iso639a2 as _ImportedBinding__iso639a2
+from . import _ddexC as _ImportedBinding__ddexC
+from . import _ddex as _ImportedBinding__ddex
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ddex.net/xml/ern/35', create_if_missing=True)

--- a/ddexreader/ern351/__init__.py
+++ b/ddexreader/ern351/__init__.py
@@ -1,1 +1,1 @@
-from binding import *
+from .binding import *

--- a/ddexreader/ern351/_ddexC.py
+++ b/ddexreader/ern351/_ddexC.py
@@ -25,10 +25,10 @@ if pyxb.__version__ != _PyXBVersion:
 
 # Import bindings for namespaces imported into schema
 import pyxb.binding.datatypes
-import _ddex as _ImportedBinding__ddex
-import _iso639a2 as _ImportedBinding__iso639a2
-import _iso3166a2 as _ImportedBinding__iso3166a2
-import _iso4217a as _ImportedBinding__iso4217a
+from . import _ddex as _ImportedBinding__ddex
+from . import _iso639a2 as _ImportedBinding__iso639a2
+from . import _iso3166a2 as _ImportedBinding__iso3166a2
+from . import _iso4217a as _ImportedBinding__iso4217a
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ddex.net/xml/20121219/ddexC', create_if_missing=True)

--- a/ddexreader/ern351/binding.py
+++ b/ddexreader/ern351/binding.py
@@ -25,9 +25,9 @@ if pyxb.__version__ != _PyXBVersion:
 
 # Import bindings for namespaces imported into schema
 import pyxb.binding.datatypes
-import _ddexC as _ImportedBinding__ddexC
-import _iso639a2 as _ImportedBinding__iso639a2
-import _ddex as _ImportedBinding__ddex
+from . import _ddexC as _ImportedBinding__ddexC
+from . import _iso639a2 as _ImportedBinding__iso639a2
+from . import _ddex as _ImportedBinding__ddex
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ddex.net/xml/ern/351', create_if_missing=True)

--- a/ddexreader/ern36/__init__.py
+++ b/ddexreader/ern36/__init__.py
@@ -1,1 +1,1 @@
-from binding import *
+from .binding import *

--- a/ddexreader/ern36/binding.py
+++ b/ddexreader/ern36/binding.py
@@ -25,7 +25,7 @@ if pyxb.__version__ != _PyXBVersion:
 
 # Import bindings for namespaces imported into schema
 import pyxb.binding.datatypes
-import _avs as _ImportedBinding__avs
+from . import _avs as _ImportedBinding__avs
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ddex.net/xml/ern/36', create_if_missing=True)


### PR DESCRIPTION
These changes allow tests to pass on python 3.7 (using explicit relative imports, byte strings). I haven't checked whether these are compatible with previous versions.